### PR TITLE
Fix BaseSettings import for compatibility

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,10 +1,14 @@
+try:
+    from pydantic_settings import BaseSettings
+except ImportError:  # Fall back to pydantic<2
+    from pydantic import BaseSettings
 
-from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     api_token: str = "changeme"
 
     class Config:
         env_file = ".env"
+
 
 settings = Settings()

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,6 +1,5 @@
-
-import os
 from app.core.config import settings
+
 
 def verify_token(token: str):
     return token == settings.api_token


### PR DESCRIPTION
## Summary
- fix missing `pydantic_settings` dependency by falling back to `pydantic.BaseSettings`
- remove unused `os` import in security module

## Testing
- `python -m compileall -q app`