### PR TITLE
feat: Add MCP (Model Context Protocol) integration

### DIFF
--- a/app/api/routes/mcp.py
+++ b/app/api/routes/mcp.py
@@ -1,0 +1,106 @@
+import secrets
+from typing import Optional
+
+from fastapi import APIRouter, Request, HTTPException, status, Query, Header
+
+from mcp.server.sse import SseServerTransport
+
+from app.mcp.server import mcp_server
+from app.core.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter()
+
+# Create SSE transport for MCP
+sse_transport = SseServerTransport("/mcp/messages/")
+
+
+def _verify_mcp_api_key(api_key: Optional[str]) -> bool:
+    """Verify the MCP API key using constant-time comparison."""
+    if not settings.mcp_api_key:
+        logger.warning("mcp_no_api_key_configured")
+        return False
+    if not api_key:
+        return False
+    return secrets.compare_digest(api_key, settings.mcp_api_key)
+
+
+def _extract_api_key(
+    authorization: Optional[str] = None,
+    api_key_query: Optional[str] = None,
+) -> Optional[str]:
+    """Extract API key from Authorization header or query parameter."""
+    # Try Authorization header first (Bearer token)
+    if authorization:
+        if authorization.startswith("Bearer "):
+            return authorization[7:]
+        return authorization
+    # Fall back to query parameter
+    return api_key_query
+
+
+@router.get("/sse")
+async def mcp_sse_endpoint(
+    request: Request,
+    api_key: Optional[str] = Query(None, alias="api_key"),
+    authorization: Optional[str] = Header(None),
+):
+    """SSE endpoint for MCP communication."""
+    # Verify API key
+    key = _extract_api_key(authorization, api_key)
+    if not _verify_mcp_api_key(key):
+        logger.warning(
+            "mcp_auth_failed",
+            client=request.client.host if request.client else "unknown",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing MCP API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    logger.info(
+        "mcp_client_connected",
+        client=request.client.host if request.client else "unknown",
+    )
+
+    async with sse_transport.connect_sse(
+        request.scope,
+        request.receive,
+        request._send,
+    ) as streams:
+        await mcp_server.run(
+            streams[0],
+            streams[1],
+            mcp_server.create_initialization_options(),
+        )
+
+
+@router.post("/messages/")
+async def mcp_messages_endpoint(
+    request: Request,
+    api_key: Optional[str] = Query(None, alias="api_key"),
+    authorization: Optional[str] = Header(None),
+):
+    """Handle MCP messages via POST."""
+    # Verify API key
+    key = _extract_api_key(authorization, api_key)
+    if not _verify_mcp_api_key(key):
+        logger.warning(
+            "mcp_auth_failed",
+            client=request.client.host if request.client else "unknown",
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing MCP API key",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    logger.debug("mcp_message_received")
+    return await sse_transport.handle_post_message(
+        request.scope,
+        request.receive,
+        request._send,
+    )

--- a/app/core/logging.py
+++ b/app/core/logging.py
@@ -53,6 +53,14 @@ def setup_logging() -> None:
     logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
     logging.getLogger("docker").setLevel(logging.WARNING)
 
+    # MCP library logging - suppress verbose logs unless mcp_debug is enabled
+    if not settings.mcp_debug:
+        logging.getLogger("mcp").setLevel(logging.WARNING)
+        logging.getLogger("mcp.server").setLevel(logging.WARNING)
+        logging.getLogger("mcp.server.sse").setLevel(logging.WARNING)
+        logging.getLogger("mcp.shared").setLevel(logging.WARNING)
+        logging.getLogger("sse_starlette").setLevel(logging.WARNING)
+
 
 def get_logger(name: str) -> structlog.stdlib.BoundLogger:
     """Get a structured logger instance."""

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ from slowapi.errors import RateLimitExceeded
 from docker.errors import NotFound, APIError, DockerException
 from jose import JWTError
 
-from app.api.routes import containers, auth, images, system, stats, realtime
+from app.api.routes import containers, auth, images, system, stats, realtime, mcp
 from app.core.config import settings
 from app.core.limiter import limiter
 from app.core.logging import setup_logging, get_logger
@@ -37,6 +37,7 @@ async def lifespan(app: FastAPI):
         app_name=settings.app_name,
         debug=settings.debug,
         rate_limiting=settings.rate_limit_enabled,
+        mcp_enabled=settings.mcp_enabled,
     )
 
     # Verify Docker connection on startup
@@ -98,3 +99,7 @@ app.include_router(images.router, prefix=f"{API_V1_PREFIX}/images", tags=["Image
 app.include_router(system.router, prefix=API_V1_PREFIX, tags=["System"])
 app.include_router(stats.router, prefix=f"{API_V1_PREFIX}/stats", tags=["Stats"])
 app.include_router(realtime.router, prefix=API_V1_PREFIX, tags=["Realtime"])
+
+# MCP (Model Context Protocol) endpoint - no auth required for AI assistants
+if settings.mcp_enabled:
+    app.include_router(mcp.router, prefix="/mcp", tags=["MCP"])

--- a/app/mcp/server.py
+++ b/app/mcp/server.py
@@ -1,0 +1,209 @@
+from mcp.server import Server
+from mcp.types import Tool, TextContent
+
+from app.services import docker_service
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Create MCP server instance
+mcp_server = Server("docker-agent")
+
+
+@mcp_server.list_tools()
+async def list_tools() -> list[Tool]:
+    """List available MCP tools."""
+    return [
+        Tool(
+            name="docker_health",
+            description="Get Docker daemon health status and system information including container counts, memory, and CPU info",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+        ),
+        Tool(
+            name="docker_version",
+            description="Get Docker version information",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+        ),
+        Tool(
+            name="list_containers",
+            description="List all Docker containers with their status, image, and port information",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "all": {
+                        "type": "boolean",
+                        "description": "Include stopped containers (default: true)",
+                        "default": True,
+                    }
+                },
+                "required": [],
+            },
+        ),
+        Tool(
+            name="get_container",
+            description="Get detailed information about a specific container including config, state, mounts, and networks",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "container_id": {
+                        "type": "string",
+                        "description": "Container ID or name",
+                    }
+                },
+                "required": ["container_id"],
+            },
+        ),
+        Tool(
+            name="get_container_logs",
+            description="Get logs from a specific container",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "container_id": {
+                        "type": "string",
+                        "description": "Container ID or name",
+                    },
+                    "tail": {
+                        "type": "integer",
+                        "description": "Number of lines to return from the end (default: 100)",
+                        "default": 100,
+                    },
+                },
+                "required": ["container_id"],
+            },
+        ),
+        Tool(
+            name="get_container_stats",
+            description="Get resource usage statistics (CPU, memory, network, block I/O) for a container",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "container_id": {
+                        "type": "string",
+                        "description": "Container ID or name",
+                    }
+                },
+                "required": ["container_id"],
+            },
+        ),
+        Tool(
+            name="list_images",
+            description="List all Docker images with their tags and sizes",
+            inputSchema={"type": "object", "properties": {}, "required": []},
+        ),
+        Tool(
+            name="start_container",
+            description="Start a stopped container",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "container_id": {
+                        "type": "string",
+                        "description": "Container ID or name",
+                    }
+                },
+                "required": ["container_id"],
+            },
+        ),
+        Tool(
+            name="stop_container",
+            description="Stop a running container",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "container_id": {
+                        "type": "string",
+                        "description": "Container ID or name",
+                    }
+                },
+                "required": ["container_id"],
+            },
+        ),
+        Tool(
+            name="restart_container",
+            description="Restart a container",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "container_id": {
+                        "type": "string",
+                        "description": "Container ID or name",
+                    },
+                    "timeout": {
+                        "type": "integer",
+                        "description": "Timeout in seconds before killing the container (default: 10)",
+                        "default": 10,
+                    },
+                },
+                "required": ["container_id"],
+            },
+        ),
+    ]
+
+
+@mcp_server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    """Handle tool calls."""
+    logger.debug("mcp_tool_called", tool=name, arguments=arguments)
+
+    try:
+        if name == "docker_health":
+            result = docker_service.get_system_info()
+
+        elif name == "docker_version":
+            version = docker_service.get_version()
+            result = version.model_dump()
+
+        elif name == "list_containers":
+            include_all = arguments.get("all", True)
+            containers = docker_service.list_containers(all=include_all)
+            result = [c.model_dump() for c in containers]
+
+        elif name == "get_container":
+            container_id = arguments["container_id"]
+            result = docker_service.get_container_details(container_id)
+
+        elif name == "get_container_logs":
+            container_id = arguments["container_id"]
+            tail = arguments.get("tail", 100)
+            result = docker_service.get_logs(container_id, tail=tail)
+
+        elif name == "get_container_stats":
+            container_id = arguments["container_id"]
+            stats = docker_service.get_container_stats(container_id)
+            result = stats.model_dump()
+
+        elif name == "list_images":
+            images = docker_service.list_images()
+            result = [img.model_dump() for img in images]
+
+        elif name == "start_container":
+            container_id = arguments["container_id"]
+            docker_service.start_container(container_id)
+            result = {"status": "started", "container_id": container_id}
+
+        elif name == "stop_container":
+            container_id = arguments["container_id"]
+            docker_service.stop_container(container_id)
+            result = {"status": "stopped", "container_id": container_id}
+
+        elif name == "restart_container":
+            container_id = arguments["container_id"]
+            timeout = arguments.get("timeout", 10)
+            docker_service.restart_container(container_id, timeout=timeout)
+            result = {"status": "restarted", "container_id": container_id}
+
+        else:
+            logger.warning("mcp_unknown_tool", tool=name)
+            return [TextContent(type="text", text=f"Unknown tool: {name}")]
+
+        # Convert result to string for text content
+        import json
+        text_result = json.dumps(result, indent=2, default=str)
+        logger.debug("mcp_tool_success", tool=name)
+        return [TextContent(type="text", text=text_result)]
+
+    except Exception as e:
+        logger.error("mcp_tool_error", tool=name, error=str(e))
+        return [TextContent(type="text", text=f"Error: {str(e)}")]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,7 @@ gunicorn==23.0.0
 
 # Structured logging
 structlog==24.4.0
+
+# MCP (Model Context Protocol)
+mcp[cli]==1.3.0
+sse-starlette>=2.1.0


### PR DESCRIPTION
## Summary
Adds MCP support so AI assistants (Claude, Cursor, etc.) can interact with Docker through standardized tools.

## What's new
- **MCP Server** with 10 Docker tools: health checks, container management (list/start/stop/restart), logs, stats, and images
- **SSE transport** at `/mcp/sse` and `/mcp/messages/` endpoints
- **API key authentication** for MCP (separate from JWT auth)
- **Configuration options**: `MCP_ENABLED`, `MCP_DEBUG`, `MCP_API_KEY`

## New dependencies
- `mcp[cli]==1.3.0`
- `sse-starlette>=2.1.0`

## Usage
Set `MCP_API_KEY` in your `.env` and connect your AI assistant to `/mcp/sse`.